### PR TITLE
Name Change

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>WCAG Maturity Model</title>
+    <title>W3C Accessibility Maturity Model</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class='remove'>
       // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
@@ -39,7 +39,7 @@
   </head>
   <body>
     <section id="abstract">
-      <p>WCAG Maturity Model guides a public or private organization to design, implement and evaluate their processes to produce digital products that are accessible to people with disabilities.  It is designed to work for many different size organizations from s to large corporations or government agencies. </p>
+      <p>W3C Accessibility Maturity Model guides a public or private organization to design, implement and evaluate their processes to produce digital products that are accessible to people with disabilities.  It is designed to work for many different size organizations from s to large corporations or government agencies. </p>
       </p>
     </section>
     <section id="sotd">
@@ -55,9 +55,9 @@
         for how toget started!
       </p>
       <section>
-        <h3>About WCAG Maturity Model</h3>
+        <h3>About W3C Accessibility Maturity Model</h3>
         <p>ICT Accessibility within organizations of any size can be complex with multiple dimensions.  Although some organizations have individuals or departments to support accessibility, many organizations lack understanding or fail to recognize the importance of ICT accessibility as a requirement, and therefore don’t realize they need accessibility governance systems. This can result in limits to the ability to produce accessible products and associated services such as training and documentation which are essential for inclusive digital environments. The solution to this challenge is to encourage organizations to establish and implement accessibility governance systems within their organizations. These systems must integrate ICT accessibility criteria into policies, key business processes, organizational culture, and management structures in a consistent, repeatable, and measurable fashion. Only then can organizations address the complexities related to enabling ICT accessibility.</p>
-        <p>This proposed WCAG Maturity Model describes an overall framework for establishing a robust ICT accessibility program and identifying areas for improvement. ​A Maturity Model is:</p>
+        <p>This proposed W3C Accessibility Maturity Model describes an overall framework for establishing a robust ICT accessibility program and identifying areas for improvement. ​A Maturity Model is:</p>
         <p>A tool;</p>
         <ol>
           <li>That helps people assess the current effectiveness of a person, group, or an organization;</li>
@@ -75,7 +75,7 @@
         </ul>
       </section>
       <section id="WCAG-maturity-model-audience">
-        <h2>WCAG Maturity Model Audience</h2>
+        <h2>W3C Accessibility Maturity Model Audience</h2>
         <p>This document is intended to guide and evaluate the levels of organizational accessibility maturity that encompasses a public or private sector organization at any scale.</p>
         <p>Examples of organizations might be (but not limited to):</p>
         <ul>


### PR DESCRIPTION
from WCAG Maturity Model to W3C Accessibility Maturity Model.  WCAG needs to be spelled out and then the name differences become significant.  A name without an acrronym is a better solution.